### PR TITLE
create switch replacement

### DIFF
--- a/switch replacement
+++ b/switch replacement
@@ -1,0 +1,19 @@
+# Function to convert number into string 
+# Switcher is dictionary data type here 
+def numbers_to_strings(argument): 
+    switcher = { 
+        0: "zero", 
+        1: "one", 
+        2: "two", 
+    } 
+  
+    # get() method of dictionary data type returns  
+    # value of passed argument if it is present  
+    # in dictionary otherwise second argument will 
+    # be assigned as default value of passed argument 
+    return switcher.get(argument, "nothing") 
+  
+# Driver program 
+if __name__ == "__main__": 
+    argument=0
+    print numbers_to_strings(argument) 

--- a/switch replacement
+++ b/switch replacement
@@ -16,4 +16,4 @@ def numbers_to_strings(argument):
 # Driver program 
 if __name__ == "__main__": 
     argument=0
-    print numbers_to_strings(argument) 
+    print (numbers_to_strings(argument))


### PR DESCRIPTION
What is the replacement of Switch Case in Python ?

Unlike every other programming language we have used before, Python does not have a switch or case statement. To get around this fact, we use dictionary mapping.